### PR TITLE
Check actual tabs

### DIFF
--- a/lib/alert.js
+++ b/lib/alert.js
@@ -24,18 +24,33 @@ function verify(url){
 	else{
 		chrome.browserAction.setBadgeText({text: ""});
 	}
-};
+}
 
+function check_page(tabId) {
+    chrome.tabs.get(tabId, function(tab) {
+        verify(tab.url);
+    })
+}
+
+// check when a user switches to a different tab
 chrome.tabs.onSelectionChanged.addListener(function(tabId, props) {
-    chrome.tabs.query({active: true}, function(tabs) {
-        var current = tabs[0].url;
-        verify(current);
-    });
+    check_page(tabId);
 });
 
-chrome.extension.onMessage.addListener(function(request, sender) {
-		chrome.tabs.query({active: true}, function(tabs) {
-				var current = tabs[0].url;
-				verify(current);
-		});
+// check when a tab loads a url
+// todo: if the user reopens a window that had several tabs (eg. recovering from
+// a crash), then the user will get a sep. notification for each tab that has a
+// punycode url loaded. this will be
+// 1. spammy
+// 2. ambiguous. the notifications assume the user is looking at the current tab
+chrome.webNavigation.onCompleted.addListener(function(details) {
+    check_page(details.tabId)
 });
+
+// todo: i'm not sure what use case this is covering
+// chrome.extension.onMessage.addListener(function(request, sender) {
+// 		chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tabs) {
+// 				var current = tabs[0].url;
+// 				verify(current);
+// 		});
+// });

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,19 @@
 {
 	"name": "Punycode alert",
 	"description": "A extension that alerts you when a url written in unicode is opened.",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"manifest_version": 2,
 	"background": {
 		"persistent": false,
 		"scripts": ["lib/alert.js"]
 	},
-	"permissions": ["tabs", "notifications"],
+	"content_scripts": [
+		{
+			"matches": ["*://*/*", "*://*/*"],
+			"js": ["lib/alert.js"]
+		}
+	],
+	"permissions": ["tabs", "notifications", "webNavigation"],
 	"icons": { "16": "img/scan.png", "128": "img/scan-128.png" },
 	"browser_action": {
 		"default_icon": "img/scan.png",


### PR DESCRIPTION
Previous code queried for active tabs and only checked the first result. But there can be multiple windows open and they all have one active tab. So there was a chance the extension checked the wrong URL.

- Use `tabId` from callbacks to get the actual tab data and URL
- Run the check when a tab loads a new URL
- Commented out the `extension.onMessage` callback. I'm not sure what use case that's addressing?
- Bump version

TODOs:
- Handle when a window is restored (multiple tabs load, possible notification spam)